### PR TITLE
Add support for languageCode as a request parameter (AWS Lambda event attribute)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile fileTree(dir: 'jars', include: '*.jar')
     compile group: 'io.reactivex.rxjava2', name: 'rxjava', version: '2.2.2'
     compile(
-            'software.amazon.awssdk:transcribestreaming:2.2.0',
+            'software.amazon.awssdk:transcribestreaming:2.5.0',
 
             'com.amazonaws:aws-java-sdk-dynamodb:1.11.475',
             'com.amazonaws:aws-java-sdk-kinesisvideo:1.11.475',

--- a/src/main/java/com/amazonaws/kvstranscribestreaming/TranscriptionRequest.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/TranscriptionRequest.java
@@ -18,6 +18,7 @@ package com.amazonaws.kvstranscribestreaming;
  */
 
 import java.util.Optional;
+import software.amazon.awssdk.services.transcribestreaming.model.LanguageCode;
 
 public class TranscriptionRequest {
 
@@ -106,6 +107,11 @@ public class TranscriptionRequest {
 
         // language code is optional; if provided, it should be one of the values accepted by
         // https://docs.aws.amazon.com/transcribe/latest/dg/API_streaming_StartStreamTranscription.html#API_streaming_StartStreamTranscription_RequestParameters
+        if (languageCode.isPresent()) {
+            if (!LanguageCode.knownValues().contains(LanguageCode.fromValue(languageCode.get()))) {
+                throw new IllegalArgumentException("Incorrect language code");
+            }
+        }
     }
 
 }

--- a/src/main/java/com/amazonaws/kvstranscribestreaming/TranscriptionRequest.java
+++ b/src/main/java/com/amazonaws/kvstranscribestreaming/TranscriptionRequest.java
@@ -16,12 +16,16 @@ package com.amazonaws.kvstranscribestreaming;
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
+import java.util.Optional;
+
 public class TranscriptionRequest {
 
     String streamARN = null;
     String inputFileName = null;
     String startFragmentNum = null;
     String connectContactId = null;
+    Optional<String> languageCode = Optional.empty();
     boolean transcriptionEnabled = false;
 
     public String getStreamARN() {
@@ -64,6 +68,19 @@ public class TranscriptionRequest {
         this.connectContactId = connectContactId;
     }
 
+    public Optional<String> getLanguageCode() {
+
+        return this.languageCode;
+    }
+
+    public void setLanguageCode(String languageCode) {
+
+        if ((languageCode != null) && (languageCode.length() > 0)) {
+
+            this.languageCode = Optional.of(languageCode);
+        }
+    }
+
     public void setTranscriptionEnabled(boolean enabled) {
         transcriptionEnabled = enabled;
     }
@@ -74,8 +91,8 @@ public class TranscriptionRequest {
 
     public String toString() {
 
-        return String.format("streamARN=%s, startFragmentNum=%s, connectContactId=%s, transcriptionEnabled=%s",
-                getStreamARN(), getStartFragmentNum(), getConnectContactId(), isTranscriptionEnabled());
+        return String.format("streamARN=%s, startFragmentNum=%s, connectContactId=%s, languageCode=%s, transcriptionEnabled=%s",
+                getStreamARN(), getStartFragmentNum(), getConnectContactId(), getLanguageCode(), isTranscriptionEnabled());
     }
 
     public void validate() throws IllegalArgumentException {
@@ -86,6 +103,9 @@ public class TranscriptionRequest {
         // complain if none are provided
         if ((getStreamARN() == null) && (getInputFileName() == null))
             throw new IllegalArgumentException("One of streamARN or inputFileName must be provided");
+
+        // language code is optional; if provided, it should be one of the values accepted by
+        // https://docs.aws.amazon.com/transcribe/latest/dg/API_streaming_StartStreamTranscription.html#API_streaming_StartStreamTranscription_RequestParameters
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

The new parameter is optional (en-US is still used by default).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
